### PR TITLE
Add banner image to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Tests](https://github.com/papermerge/papermerge-core/actions/workflows/tests.yml/badge.svg)](https://github.com/papermerge/papermerge-core/actions/workflows/tests.yml)
 
+![GE-OCR banner](documentation/github_banner.png)
+
 # Grammatically-Enhanced-OCR API (GE-OCR)
 
 Provides core functionality to web frontend. Based on enhancements of the open source Papermerge REST API Server version 2.1.


### PR DESCRIPTION
## Summary
- display project banner from documentation/github_banner.png at top of README

## Testing
- `pre-commit run --files README.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bab91315ac832ca68e61cf9f15db48